### PR TITLE
ISNUMERIC translation for the Teradata dialect

### DIFF
--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -899,7 +899,7 @@ teradata,SELECT TOP @([0-9]+)rows @a;,SELECT @a SAMPLE @rows;
 teradata,(SELECT TOP @([0-9]+)rows @a),(SELECT @a SAMPLE @rows)
 --teradata,hacks,begin
 teradata,"ISNUMERIC(abs(@a))","CASE WHEN tryCast(CAST(@a AS CHAR(1000)) AS BIGINT) is not null THEN 1 ELSE 0 END"
-teradata,"ISNUMERIC(@a)","CASE WHEN TryCast(@a) THEN 1 ELSE 0 END"
+teradata,"ISNUMERIC(@a)","CASE WHEN tryCast(CAST(@a AS CHAR(1000)) AS BIGINT) is not null THEN 1 ELSE 0 END"
 teradata,!=, <>
 teradata,!=, <>
 teradata,.DOMAIN, ."DOMAIN"

--- a/inst/csv/replacementPatterns.csv
+++ b/inst/csv/replacementPatterns.csv
@@ -898,7 +898,7 @@ teradata,#,
 teradata,SELECT TOP @([0-9]+)rows @a;,SELECT @a SAMPLE @rows;
 teradata,(SELECT TOP @([0-9]+)rows @a),(SELECT @a SAMPLE @rows)
 --teradata,hacks,begin
-teradata,"ISNUMERIC(abs(@a))","CASE WHEN tryCast(CAST(@a AS CHAR(1000)) AS INT) is not null THEN 1 ELSE 0 END"
+teradata,"ISNUMERIC(abs(@a))","CASE WHEN tryCast(CAST(@a AS CHAR(1000)) AS BIGINT) is not null THEN 1 ELSE 0 END"
 teradata,"ISNUMERIC(@a)","CASE WHEN TryCast(@a) THEN 1 ELSE 0 END"
 teradata,!=, <>
 teradata,!=, <>


### PR DESCRIPTION
Fixed ISNUMERIC translation for the Teradata dialect.
Previously it produced incorrect results for numbers greater than 2^32.